### PR TITLE
[BugFix] Resolves the problem that texts escape from the origin card 

### DIFF
--- a/functions/TransitionVariants.tsx
+++ b/functions/TransitionVariants.tsx
@@ -17,25 +17,25 @@ const TransitionVariants = {
   TransitionContextLToR: {
     initial: {opacity: 0, x: -200, transition: {duration: 0.6}},
     open: {opacity: 1, x: 0, transition: {duration: 0.6}},
-    close2: {x: "-20vw", transition: {duration: 0.6}},
+    close2: {x: -400, opacity: 0, transition: {duration: 0.6}},
   },
 
   TransitionContextLToR2: {
     initial: {opacity: 0, x: -200, transition: {duration: 0.6}},
     open: {opacity: 1, x: 0, transition: {duration: 0.6}},
-    close2: {x: "-46vw", transition: {duration: 0.6}},
+    close2: {x: -400, opacity: 0, transition: {duration: 0.6}},
   },
 
   TransitionContextRToL: {
     initial: {opacity: 0, x: 200, transition: {duration: 0.6}},
     open: {opacity: 1, x: 0, transition: {duration: 0.6}},
-    close2: {x: "20vw", transition: {duration: 0.6}},
+    close2: {x: 400, opacity: 0, transition: {duration: 0.6}},
   },
 
   TransitionContextTToB: {
     initial: {z: 0, opacity: 0, y: -200, transition: {duration: 0.6}},
     open: {z: 0, opacity: 1, y: 0, transition: {duration: 0.6}},
-    close2: {z: 0, y: "-40vh", transition: {duration: 0.6}},
+    close2: {z: 0, opacity: 0, y: -400, transition: {duration: 0.6}},
   },
 };
 


### PR DESCRIPTION
### 작성자
최정윤

### 1. 기능 설명 
**슬라이딩 카드**
- 카드 닫혔을 때의 위치 수정
- 카드 닫혔을 때  글씨 컴포넌트의 투명도 -> 0으로 수정
  - 글씨 삐져나와도 안보이게 하기 위함 