### PR TITLE
[Style] Update margin and padding in landing page 

### DIFF
--- a/components/LandingComponents.tsx/MeasureCard.tsx
+++ b/components/LandingComponents.tsx/MeasureCard.tsx
@@ -270,7 +270,7 @@ from{
   margin-right:5%;
 }to{
   width:600px;
-  margin-right:5%;
+  margin-right:0%;
 }
 `;
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -70,7 +70,7 @@ function Home() {
           <div className="py-[3vh] mx-[3vw]  cursor-pointer">보고서</div>
         </Link>
       </section>
-      <section className="flex-col justify-center items-center 2xl:w-[1450px]  mx-auto px-[30px] pb-[130px] ">
+      <section className="flex-col justify-center items-center 2xl:w-[1450px]  mx-auto 2xl:px-[120px] px-[3vw] pb-[130px] ">
         {/* Measure Section */}
         <section id="measure" className="scroll-mt-28 ">
           <SectionTitleStyle>{LandingContents.Measure.title}</SectionTitleStyle>
@@ -104,7 +104,6 @@ function Home() {
           <div className="hidden md:block">
             <ReduceCards />
           </div>
-
 
           {/* When display is small than md */}
           <div className="md:hidden">

--- a/styles/commonStyles.ts
+++ b/styles/commonStyles.ts
@@ -97,6 +97,7 @@ export const SectionTitleStyle = styled.div`
   font-size: 10vw;
   font-weight: 600;
   margin-bottom: 2vh;
+  margin-top: 3vh;
   @media only screen and (min-width: 640px) {
     font-size: 5vw;
   }


### PR DESCRIPTION
### 작성자 
최정윤 

### 1. 기능 설명 
- 랜딩 페이지의 전체 패딩 수정 
- 패딩 수정으로 인한 measure 카드의 애니메이션 margin 수정 
- 모바일 페이지: landing title section title의 top margin 수정 