### PR TITLE
[FeatDone] Update things about requirements

### DIFF
--- a/components/CompanyComponents/HistoryCard.tsx
+++ b/components/CompanyComponents/HistoryCard.tsx
@@ -1,8 +1,10 @@
 import React, {memo, useState} from "react";
 import {HistoryContentType} from "../../functions/HistoryContents";
+import useHover from "../../hooks/useHover";
 
 const HistoryCard = memo(({content}: {content: HistoryContentType}) => {
   const [isOpened, setIsOpened] = useState(false);
+  const [isHover, onMouseEnter, onMouseLeave] = useHover();
   const onHistoryClick = () => {
     setIsOpened((cur) => !cur);
   };
@@ -10,11 +12,15 @@ const HistoryCard = memo(({content}: {content: HistoryContentType}) => {
     <div
       role="button"
       onClick={onHistoryClick}
-      className={` basis-[600px] my-[1vh] md:mx-[20px] flex flex-grow flex-col items-center    border-2 rounded-forImg   transition-all duration-[0.5s] bg-[white] mx-auto  ${
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={` basis-[600px] my-[1vh] md:mx-[20px] flex flex-grow flex-col items-center  border-2 rounded-forImg   transition-all duration-[0.5s] bg-[white] hover:bg-history_gradient hover:text-[white] hover:drop-shadow-md mx-auto  ${
         isOpened ? "h-[60vh] md:h-[700px]   bg-history_gradient" : "h-[11vh] md:h-[150px]"
       }`}>
       <div
         className={`text-[12vw] leading-[11vh]  md:text-[80px] md:leading-[150px] font-bold ${
+          isHover ? "drop-shadow-history_text " : " "
+        }  ${
           isOpened ? "h-[11vh] md:h-[150px] text-[white] drop-shadow-history_text " : "h-full"
         }`}>
         {content.year}

--- a/components/LayoutComponents/NavBar.tsx
+++ b/components/LayoutComponents/NavBar.tsx
@@ -5,7 +5,6 @@ import {memo} from "react";
 import styled from "styled-components";
 import {HeaderLinkButton, LinkButton} from "../../styles/commonStyles";
 import HamburgerMenu from "./Hamburger/HamburgerMenu";
-import Layout from "../Layout";
 
 function NavigationBar() {
   const router = useRouter();

--- a/components/LayoutComponents/NavBar.tsx
+++ b/components/LayoutComponents/NavBar.tsx
@@ -28,7 +28,10 @@ function NavigationBar() {
           )}
         </Link>
         <ul className="hidden sm:flex ">
-          <ProductListStyle className="mx-[0.3vw] px-[1vw] py-[1vh] text-[1.5vw] md:text-[1vw] font-medium">
+          <li className=" mx-[0.3vw]  px-[1vw] py-[1vh] text-[1.5vw] md:text-[1vw] font-medium">
+            <Link href="/product/ciet">PRODUCT</Link>
+          </li>
+          {/* <ProductListStyle className="mx-[0.3vw] px-[1vw] py-[1vh] text-[1.5vw] md:text-[1vw] font-medium">
             <a rel="noopener noreferrer" href="#">
               PRODUCT
             </a>
@@ -42,7 +45,7 @@ function NavigationBar() {
                 <span className="hover:text-constant-CIET_MINT">CIET</span>
               </Link>
             </div>
-          </ProductListStyle>
+          </ProductListStyle> */}
 
           <li className=" mx-[0.3vw]  px-[1vw] py-[1vh] text-[1.5vw] md:text-[1vw] font-medium">
             <Link href="/company">COMPANY</Link>

--- a/components/LayoutComponents/NavBar.tsx
+++ b/components/LayoutComponents/NavBar.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
+import Image from "next/image";
 import {useRouter} from "next/router";
 import {memo} from "react";
 import styled from "styled-components";
 import {HeaderLinkButton, LinkButton} from "../../styles/commonStyles";
 import HamburgerMenu from "./Hamburger/HamburgerMenu";
+import Layout from "../Layout";
 
 function NavigationBar() {
   const router = useRouter();
@@ -13,7 +15,12 @@ function NavigationBar() {
     <div className="sticky z-50  inset-x-0 top-0">
       <nav className="px-[6vw] flex place-items-center justify-between min-w-[100%] bg-white border-b-2 h-[10vh] lg:h-[12vh]">
         <Link href="/" className="flex items-center my-4">
-          {router.pathname === "/product/ciet" ? (
+          <img
+            alt="logoImg"
+            src="/images/CNRI_logo_black_under.svg"
+            className="md:h-[6.5vh] h-[4.5vh] cursor-pointer"
+          />
+          {/* {router.pathname === "/product/ciet" ? (
             <img
               alt="logoImg"
               src="/images/CIET_signature.svg"
@@ -25,7 +32,7 @@ function NavigationBar() {
               src="/images/CNRI_logo_black_under.svg"
               className="md:h-[6.5vh] h-[4.5vh] cursor-pointer"
             />
-          )}
+          )} */}
         </Link>
         <ul className="hidden sm:flex ">
           <li className=" mx-[0.3vw]  px-[1vw] py-[1vh] text-[1.5vw] md:text-[1vw] font-medium">

--- a/components/PopUp.tsx
+++ b/components/PopUp.tsx
@@ -55,7 +55,7 @@ const PopUp = () => {
               </div>
             </div>
             <footer className=" absolute w-full text-center text-white text-[13px]  leading-[50px] bottom-0 transform:transition w-full h-[40px]">
-              CNRI KOREA
+              CNRIKOREA
             </footer>
           </div>
 
@@ -112,7 +112,7 @@ const PopUp = () => {
                 </a>
               </div>
               <div className=" bottom-0 w-full h-[25%] z-[999] text-[2vw] border-t-[0.1vh] py-[0.3vh] border-dashed ">
-                CNRI KOREA
+                CNRIKOREA
               </div>
             </div>
           </MobliePopUp>

--- a/components/RAndDComponents/Arrow.tsx
+++ b/components/RAndDComponents/Arrow.tsx
@@ -13,9 +13,8 @@ const Arrow = memo(({direction}: {direction: ArrowDirection}) => (
         <path
           d="M5 22.5L22.5 5L40 22.5"
           stroke="#A8A8A8"
-          stroke-width="10"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     ) : direction === ArrowDirection.DOWN ? (
@@ -28,9 +27,9 @@ const Arrow = memo(({direction}: {direction: ArrowDirection}) => (
         <path
           d="M40 5L22.5 22.5L5 5"
           stroke="#A8A8A8"
-          stroke-width="10"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="10"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     ) : direction === ArrowDirection.RIGHT ? (
@@ -43,9 +42,9 @@ const Arrow = memo(({direction}: {direction: ArrowDirection}) => (
         <path
           d="M5 5L22.5 22.5L5 40"
           stroke="#A8A8A8"
-          stroke-width="10"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="10"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     ) : direction === ArrowDirection.LEFT ? (
@@ -58,9 +57,9 @@ const Arrow = memo(({direction}: {direction: ArrowDirection}) => (
         <path
           d="M22.5 40L5 22.5L22.5 5"
           stroke="#A8A8A8"
-          stroke-width="10"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="10"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     ) : (
@@ -74,9 +73,9 @@ const Arrow = memo(({direction}: {direction: ArrowDirection}) => (
         <path
           d="M5 22.5L22.5 5L40 22.5"
           stroke="#A8A8A8"
-          stroke-width="10"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="10"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     )}

--- a/components/RAndDComponents/Arrow.tsx
+++ b/components/RAndDComponents/Arrow.tsx
@@ -2,7 +2,7 @@ import React, {memo} from "react";
 import {ArrowDirection} from "../../constants/enum/arrow_direction.enum";
 
 const Arrow = memo(({direction}: {direction: ArrowDirection}) => (
-  <div>
+  <div className="hover:drop-shadow-xl transition-all duration-[0.2s]">
     {direction === ArrowDirection.UP ? (
       <svg
         width="100%"

--- a/components/RAndDComponents/Partnership.tsx
+++ b/components/RAndDComponents/Partnership.tsx
@@ -10,8 +10,8 @@ import Arrow from "./Arrow";
 function Partnership() {
   const [userInteracted, setUserInteracted] = useState(false); // 유저가 이미지에 호버 하거나, 아이콘에 호버를 했는지 확인. 유저한테 인터랙션이 이뤄졌는지. --> 이뤄졌다면 setUserInteracted(true)
   const [currentObj, setCurrentObj] = useState(PartnershipContent.h2); // 현제 옵젝트/아이콘
-  const [curContentTitle, setCurContentTitle] = useState<string>("");
-  const [curImgs, setCurImgs] = useState([]);
+  const [curContentTitle, setCurContentTitle] = useState<string>(PartnershipContent.snu.title);
+  const [curImgs, setCurImgs] = useState(PartnershipContent.snu.img);
   const [curImgIdx, setCurImgIdx] = useState(0);
   const contents = useRef([
     PartnershipContent.snu,
@@ -20,8 +20,6 @@ function Partnership() {
     PartnershipContent.totalBusiness,
     PartnershipContent.ts,
   ]);
-
-  const scrollRef = useRef();
 
   const onCompanyClick = (e: any) => {
     const {id} = e.currentTarget;

--- a/pages/product/ciet/index.tsx
+++ b/pages/product/ciet/index.tsx
@@ -25,6 +25,9 @@ function CietPage() {
       <NextSeo {...cietSeo} />
       <div className="snap-center snap-always pb-[5vh] md:pb-[25vh]">
         <div className="pt-[15vh] md:pt-[25vh]">
+          <div className="md:h-[4.5vh] h-[2.5vh] relative cursor-pointer  m-3 mb-4">
+            <Image alt="logoImg" src="/images/CIET_signature.svg" layout="fill" />
+          </div>
           <div className="flex justify-center font-bold text-[5vw] md:text-[4vw] 2xl:text-[3vw]">
             기후변화 대응,
           </div>


### PR DESCRIPTION
### 작성자 
최정윤 

### 1. 기능 설명 
- 헤더의 product 탭 선택 시 바로 ciet 랜딩 페이지로 이동하도록 변경
- ciet 랜딩 페이지
  - 헤더의 로고를 cnri 로고로 변경
  - 랜딩 페이지 첫 화면 text 위에 ciet 로고 삽입
- 팝업 하단의 회사명 : CNRI KOREA => CNRIKOREA 
- history 컴포넌트에 hover 효과 추가 
- 화살표 컴포넌트에 hover시 그림자 생기는 effect 추가 
- R&D 페이지의 첫번째 파트너쉽 회사 기본으로 열려있도록 구현 
- 불필요한 import 제거 및 warning 제거위한 수정 