### PR TITLE
[Bugfix] Fix that partnership mobile img distorted

### DIFF
--- a/components/RAndDComponents/PartenershipMobileContentCard.tsx
+++ b/components/RAndDComponents/PartenershipMobileContentCard.tsx
@@ -12,7 +12,7 @@ const PartenershipMobileContentCard = memo(({title, content, img, heightAuto = t
     className={`w-[80vw] flex flex-col justify-center items-center bg-partnership_bg rounded-[3vw] px-[3vw] py-[2vh] ${
       heightAuto ? "h-auto" : "h-[50vh] landscape:h-auto"
     }`}>
-    <div className="h-[60%]">{img}</div>
+    <div>{img}</div>
     <div className="px-[2vw] text-left">
       <h4 className="text-[3.6vw] font-semibold py-[1vh] pt-[1.6vh]">{title}</h4>
       <div className="text-[2vw] ">{content}</div>


### PR DESCRIPTION
### 작성자 
최정윤 

### 1. 기능 설명 
- 모바일  partnership section에서 상세 설명의 이미지가 세로로 왜곡되는 문제 해결 