### PR TITLE
[FeatDone] Optimize img of ciet landing page & company page

### DIFF
--- a/components/CompanyComponents/MemberCard.tsx
+++ b/components/CompanyComponents/MemberCard.tsx
@@ -6,7 +6,7 @@ const MemberCard = memo(({member}: {member: MemberType}) => (
   <div className="flex flex-col justify-center items-center">
     <div
       className={`w-[180px] h-[180px] rounded-[50%] translate-y-2/4 border-2 relative overflow-hidden bg-white mt-[-50px]  `}>
-      <Image layout="fill" src={member.pic_square} sizes="200px" />
+      <Image layout="fixed" src={member.pic_square} width="180px" height="180px" />
     </div>
     <div className=" w-[280px] h-[320px] border-2 rounded-forImg pt-[100px] px-10 ">
       <div className="flex flex-col justify-center items-center ">

--- a/components/CompanyComponents/PhilosophyMobile.tsx
+++ b/components/CompanyComponents/PhilosophyMobile.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Image from "next/image";
 
 interface PhilosophyMobileType {
   // 카드 내용
@@ -16,9 +17,10 @@ function PhilosophyMobile({type}: PhilosophyMobileType) {
       <div className={` h-full  flex `}>
         {/* 이미지 */}
         <div className="relative w-[80vw] rounded-r-lg  ">
-          <img
+          <Image
             alt="philImg"
             src={type.imgPath}
+            layout="fill"
             className=" object-cover h-full w-full flex-wrap  rounded-lg shadow-xl"
           />
           {/* 내용 */}

--- a/functions/PhilosophyContent.tsx
+++ b/functions/PhilosophyContent.tsx
@@ -7,7 +7,7 @@ const PhilosophyContent = {
       "지속 가능한 지구를 실현해내겠습니다.",
     ],
     videoPath: "./video/philosophy1.mp4",
-    imgPath: "./images/philosophy1Pic.png",
+    imgPath: "/images/philosophy1Pic.png",
   },
   vision: {
     title: "Vision",
@@ -17,7 +17,7 @@ const PhilosophyContent = {
       "모든 탄소를 찾아내겠습니다.",
     ],
     videoPath: "./video/philosophy2.mp4",
-    imgPath: "./images/philosophy2Pic.png",
+    imgPath: "/images/philosophy2Pic.png",
   },
   coreValues: {
     title: "Core Values",
@@ -27,7 +27,7 @@ const PhilosophyContent = {
       "기술혁신이 불러오는 세상의 변화",
     ],
     videoPath: "./video/philosophy3.mp4",
-    imgPath: "./images/philosophy3Pic.png",
+    imgPath: "/images/philosophy3Pic.png",
   },
 };
 

--- a/pages/product/ciet/index.tsx
+++ b/pages/product/ciet/index.tsx
@@ -24,9 +24,9 @@ function CietPage() {
     <div>
       <NextSeo {...cietSeo} />
       <div className="snap-center snap-always pb-[5vh] md:pb-[25vh]">
-        <div className="pt-[15vh] md:pt-[25vh]">
-          <div className="md:h-[4.5vh] h-[2.5vh] relative cursor-pointer  m-3 mb-4">
-            <Image alt="logoImg" src="/images/CIET_signature.svg" layout="fill" />
+        <div className="pt-[15vh] md:pt-[25vh] flex flex-col items-center">
+          <div className="md:h-[4.5vh] h-[2.5vh] w-[10vw] relative cursor-pointer  m-3 mb-4">
+            <Image alt="logoImg" src="/images/CIET_signature.svg" layout="fill" sizes="300px" />
           </div>
           <div className="flex justify-center font-bold text-[5vw] md:text-[4vw] 2xl:text-[3vw]">
             기후변화 대응,
@@ -79,14 +79,22 @@ function CietPage() {
           </p>
         </div>
         <ImageStyle>
-          <Image src="/images/ciet/section-1.png" layout="fill" />
+          <Image
+            src="/images/ciet/section-1.png"
+            layout="fill"
+            sizes="(max-width: 768px) 80vw, 30vw"
+          />
         </ImageStyle>
       </section>
 
       {/* section 2 */}
       <section className="w-full flex flex-col md:flex-row justify-center items-center gap-5 md:gap-10 h-screen scroll-mt-28 snap-center snap-always bg-constant-CIET_BACK">
         <ImageStyle className="puzzle order-2 md:order-1 md:mt-3">
-          <Image src="/images/ciet/section-2.png" layout="fill" />
+          <Image
+            src="/images/ciet/section-2.png"
+            layout="fill"
+            sizes="(max-width: 768px) 100vw, 80vw"
+          />
         </ImageStyle>
         <div className="flex flex-col justify-center md:justify-start order-1 md:order-2">
           <h3 className="flex flex-col justify-center  md:justify-start mb-5">
@@ -142,14 +150,18 @@ function CietPage() {
           </p>
         </div>
         <ImageStyle>
-          <Image src="/images/ciet/section-3.png" layout="fill" />
+          <Image
+            src="/images/ciet/section-3.png"
+            layout="fill"
+            sizes="(max-width: 768px) 80vw, 30vw"
+          />
         </ImageStyle>
       </section>
 
       {/* section 4 */}
       <section className="w-full flex flex-col md:flex-row justify-center items-center gap-5 md:gap-10 h-screen scroll-mt-28 snap-center snap-always bg-constant-CIET_MINT">
         <ImageStyle className="dashboard order-2 md:order-1 md:mt-8">
-          <Image src="/images/ciet/section-4.png" layout="fill" />
+          <Image src="/images/ciet/section-4.png" layout="fill" sizes="80vw" />
         </ImageStyle>
         <div className="flex flex-col justify-center md:justify-start order-1 md:order-2">
           <h3 className="flex flex-col justify-center  md:justify-start mb-5">
@@ -196,7 +208,11 @@ function CietPage() {
               </div>
               <span className="text-xl mb-2">{item.title}</span>
               <CardImageStyle>
-                <Image src={`/images/ciet/card-${item.id}.png`} layout="fill" />
+                <Image
+                  src={`/images/ciet/card-${item.id}.png`}
+                  layout="fill"
+                  sizes="(max-width : 640px) 70vw, 15vw "
+                />
               </CardImageStyle>
               <p className="font-medium hidden md:block text-center leading-8 whitespace-pre">
                 {item.description}

--- a/pages/product/ciet/index.tsx
+++ b/pages/product/ciet/index.tsx
@@ -25,7 +25,7 @@ function CietPage() {
       <NextSeo {...cietSeo} />
       <div className="snap-center snap-always pb-[5vh] md:pb-[25vh]">
         <div className="pt-[15vh] md:pt-[25vh] flex flex-col items-center">
-          <div className="md:h-[4.5vh] h-[2.5vh] w-[10vw] relative cursor-pointer  m-3 mb-4">
+          <div className="h-[2.5vh] w-[30vw] md:h-[4.5vh] md:w-[10vw]   relative cursor-pointer  m-3 mb-4">
             <Image alt="logoImg" src="/images/CIET_signature.svg" layout="fill" sizes="300px" />
           </div>
           <div className="flex justify-center font-bold text-[5vw] md:text-[4vw] 2xl:text-[3vw]">


### PR DESCRIPTION
### 작성자 
최정윤 

### 1. 기능 설명 
- ciet landing 페이지의 이미지 최적화 : 처음 로드되는 이미지 크기 -> 품질 저하되지 않는 선에서 최소화
  - 이 과정에서 ciet 로고 크기 변경 + 반응형으로 로고 크기 수정함. 
- company 페이지의 philosophy section (mobile) : img 태그 next/image의 Image로 변경 
- company 페이지의 member section : 로드되는 srcset 개수 2개로 줄임  