### PR TITLE
HOMEPAGE-22 [BugFix] Change partnership text when img changed

### DIFF
--- a/components/RAndDComponents/Partnership.tsx
+++ b/components/RAndDComponents/Partnership.tsx
@@ -61,7 +61,7 @@ function Partnership() {
               content={c}
               isLeft={idx < 3}
               isOpened={curContentTitle === c.title}
-              contentIdx={0}
+              contentIdx={curImgIdx}
               isLast={idx === contents.current.length - 1}
             />
           </div>


### PR DESCRIPTION
### 작성자 
최정윤 

### 1. 기능 설명 
- R&D 페이지의 파트너쉽 콘텐츠 중, 사진 여러개인 경우 현재 보여지는 사진에 대응하는 텍스트가 나타나도록 수정. 
  - 기존에는 사진이 변경되어도 텍스트는 그대로였음. 