### PR TITLE
[BugFix] safari details triangle disabled

### DIFF
--- a/components/LCAComponents/SectionDetail.tsx
+++ b/components/LCAComponents/SectionDetail.tsx
@@ -108,6 +108,11 @@ const DetailsSummary = styled.details`
     line-height: 1.25rem;
     color: #dcdcdc;
     margin-bottom: 1rem;
+    list-style: none;
+  }
+
+  summary::-webkit-details-marker {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
### 작성자

안경호

### 1. 기능 설명

- 사파리에서 details 태그의 좌측 삼각형 출력 제외