### PR TITLE
HOMEPAGE-39 [Patch] Hide fashion LCA, update main page layout

### DIFF
--- a/components/LayoutComponents/NavBar.tsx
+++ b/components/LayoutComponents/NavBar.tsx
@@ -102,7 +102,7 @@ function NavigationBar() {
         </ul>
 
         <div className="flex h-full items-center gap-[2vw] lg:gap-[2vw]">
-          <div className="relative">
+          {/* <div className="relative">
             <a href="https://fashion-lca.cnrikorea.com" target="_blank" rel="noreferrer">
               <FashionCarbonToolButton className="flex flex-col items-center lg:flex-row lg:gap-[0.25vw] ">
                 <span className="label lg:mr-[0.2vw] lg:text-[0.8vw] min:text-2 w-fit bg-cis_main_green text-white px-[0.5vw] py-[0.2vw] font-normal rounded-[0.6vw]    ">
@@ -128,7 +128,7 @@ function NavigationBar() {
                 </div>
               </FashionCarbonBubble>
             ) : null}
-          </div>
+          </div> */}
           <a href="https://cis.cnrikorea.com" target="_blank" rel="noreferrer">
             <CarbonToolButton className="text-cis_main_green">
               탄소회계

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,14 +50,14 @@ const CardSection = styled.div`
   }
 `;
 
-const ButtonSection = styled.div`
-  margin: auto;
+// const ButtonSection = styled.div`
+//   margin: auto;
 
-  width: 100vw;
-  height: 50vh;
+//   width: 100vw;
+//   height: 50vh;
 
-  @media screen and (min-width: 1200px) {
-    width: 1280px;
-    height: 180px;
-  }
-`;
+//   @media screen and (min-width: 1200px) {
+//     width: 1280px;
+//     height: 180px;
+//   }
+// `;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ function Home() {
 
 export default memo(Home);
 const Wrapper = styled.div`
-  min-height: 70vh;
+  min-height: 65.8vh;
   height: 100%;
   width: 100%;
 `;
@@ -44,8 +44,8 @@ const CardSection = styled.div`
 
   @media screen and (min-width: 1200px) {
     width: 1280px;
-    height: 490px;
-    padding: 40px 0;
+    height: 600px;
+    padding: 60px 0 40px 0;
     margin: 0 auto;
   }
 `;


### PR DESCRIPTION
### 작성자

최정윤

### 1. 기능 설명

- 패션 LCA 숨김 처리 
- 메인 홈페이지 공백 채워지도록 레이아웃 조정 


### 2. 추가 설명 
![image](https://user-images.githubusercontent.com/77582221/231922551-f5a5337f-d849-4df7-b8b8-d4a0e86f4b64.png)

