### PR TITLE
[Patch] Remove phone number, remove carbon accounting tool link 

### DIFF
--- a/components/LayoutComponents/Footer.tsx
+++ b/components/LayoutComponents/Footer.tsx
@@ -19,7 +19,7 @@ function Footer() {
           ? "bg-beige_bg_2"
           : ""
       }`}>
-      <div className="h-fit w-screen py-12 flex justify-center border-2">
+      <div className="h-fit w-screen py-12 flex justify-center border-t-2">
         <div className="w-full px-2 md:w-2/3 grid grid-rows-2 md:grid-rows-1 grid-cols-1 md:grid-cols-2 gap-4 text-xs">
           <div className="relative flex flex-col space-y-2 justify-between">
             <img
@@ -50,10 +50,6 @@ function Footer() {
               <span className="col-span-3">
                 서울특별시 관악구 남부순환로 1793(백광빌딩), 9층 CNRIKOREA
               </span>
-            </div>
-            <div className="grid grid-cols-4 ">
-              <span className="font-semibold">TEL</span>
-              <span className="col-span-3">010-3652-8419</span>
             </div>
             <div className="grid grid-cols-4 ">
               <span className="font-semibold">E-mail</span>

--- a/components/LayoutComponents/NavBar.tsx
+++ b/components/LayoutComponents/NavBar.tsx
@@ -129,13 +129,13 @@ function NavigationBar() {
               </FashionCarbonBubble>
             ) : null}
           </div> */}
-          <a href="https://cis.cnrikorea.com" target="_blank" rel="noreferrer">
-            <CarbonToolButton className="text-cis_main_green">
-              탄소회계
-              <br className="block lg:hidden" />
-              산정툴
-            </CarbonToolButton>
-          </a>
+          {/* <a href="https://cis.cnrikorea.com" target="_blank" rel="noreferrer"> */}
+          <CarbonToolButton className="text-cis_main_green invisible pointer-events-none">
+            탄소회계
+            <br className="block lg:hidden" />
+            산정툴
+          </CarbonToolButton>
+          {/* </a> */}
           <button type="button" className="sm:hidden">
             <HamburgerMenu />
           </button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ function Home() {
 
 export default memo(Home);
 const Wrapper = styled.div`
-  min-height: 65.8vh;
+  min-height: 66.9vh;
   height: 100%;
   width: 100%;
 `;


### PR DESCRIPTION
### 작성자

최정윤

### 1. 기능 설명

HOMEPAGE-41
탄소회계산정툴 링크 숨김 처리 및 클릭 방지 처리  

HOMEPAGE-42
footer의 휴대전화 번호 삭제 


### 2. 추가 내용 (optional)

![image](https://user-images.githubusercontent.com/77582221/233951036-b7253286-208d-4b9e-b5f6-de0c3b284176.png)

